### PR TITLE
refactor: 슬랙처리의 대상, 비대상을 구분할수있어야 함

### DIFF
--- a/laboratory/libs/domains/conversation-log/entities/conversation-log.entity.ts
+++ b/laboratory/libs/domains/conversation-log/entities/conversation-log.entity.ts
@@ -10,6 +10,10 @@ export interface ConversationLog {
   is_thread_reply: boolean;
   is_mention: boolean;
   mentioned_user?: string | null;
+  mentioned_users?: string[];
   is_reminder_thread: boolean;
+  is_reminder_target?: boolean;
+  reminder_target_user?: string | null;
+  authorization_users?: string[];
   created_at?: Date;
 }

--- a/laboratory/libs/domains/conversation-log/repositories/conversation-log.repository.ts
+++ b/laboratory/libs/domains/conversation-log/repositories/conversation-log.repository.ts
@@ -34,4 +34,15 @@ export class ConversationLogRepository extends BaseRepository<ConversationLog> {
       .where('thread_ts', threadTs)
       .orderBy('message_ts', 'asc') as Promise<ConversationLog[]>;
   }
+
+  // 스레드의 원본 메시지 조회 (스레드 타임스탬프와 동일한 메시지 타임스탬프를 가진 메시지)
+  async findThreadOriginMessage(
+    threadTs: string,
+  ): Promise<ConversationLog | null> {
+    const messages = await this.knex(this.tableName)
+      .where('message_ts', threadTs)
+      .limit(1);
+
+    return messages.length > 0 ? (messages[0] as ConversationLog) : null;
+  }
 }

--- a/laboratory/libs/domains/conversation-log/services/conversation-log.service.ts
+++ b/laboratory/libs/domains/conversation-log/services/conversation-log.service.ts
@@ -5,7 +5,11 @@ import { ConversationLog } from '../entities/conversation-log.entity';
 
 import { MemberRepository } from 'libs/domains/member/repositories/member.repository';
 import {
+  extractAllMentionedUsers,
+  extractFirstMentionedUser,
+  extractReminderTargetUser,
   isEventCallback,
+  isReminderBotMessage,
   isReminderBotParent,
   isThreadMessage,
   SlackMessageEvent,
@@ -21,17 +25,39 @@ export class ConversationLogService {
     private readonly memberRepository: MemberRepository,
   ) {}
 
-  // 멘션 추출 함수 추가
+  // 멘션 추출 함수 - 개선된 버전 사용
   private extractMention(text: string): string | null {
-    const mentionRegex = /<@([A-Z0-9]+)>/;
-    const match = text.match(mentionRegex);
-    return match ? match[1] : null;
+    return extractFirstMentionedUser(text);
   }
 
   // 메시지에 멘션이 있는지 확인하는 함수
   private isMentioned(messageEvent: SlackMessageEvent): boolean {
-    const mentionRegex = /<@([A-Z0-9]+)>/;
-    return mentionRegex.test(messageEvent.text);
+    return extractAllMentionedUsers(messageEvent.text).length > 0;
+  }
+
+  // 스레드의 타겟 사용자 식별 (리마인더봇이 언급한 사용자)
+  private async identifyThreadTargetUser(
+    threadTs: string,
+  ): Promise<string | null> {
+    try {
+      // 스레드의 원본 메시지 조회
+      const originMessage =
+        await this.conversationLogRepository.findThreadOriginMessage(threadTs);
+
+      // 원본 메시지가 없거나 리마인더봇 메시지가 아닌 경우
+      if (!originMessage || !originMessage.is_reminder_thread) {
+        return null;
+      }
+
+      // 리마인더봇이 첫 번째로 멘션한 사용자를 타겟으로 간주
+      return originMessage.mentioned_users?.[0] || null;
+    } catch (error) {
+      this.logger.error(
+        `Failed to identify thread target user: ${error.message}`,
+        error.stack,
+      );
+      return null;
+    }
   }
 
   async processWebhookEvent(event: SlackWebhookEvent): Promise<boolean> {
@@ -42,8 +68,9 @@ export class ConversationLogService {
 
     const messageEvent = event.event;
 
-    // 봇 메시지는 무시 (필요에 따라 조정)
-    if (messageEvent.bot_id) {
+    // 봇 메시지 처리 (리마인더봇 메시지는 저장, 다른 봇은 무시)
+    const isReminderBot = isReminderBotMessage(messageEvent);
+    if (messageEvent.bot_id && !isReminderBot) {
       return false;
     }
 
@@ -55,10 +82,30 @@ export class ConversationLogService {
       const memberCode = member ? member.member_code : '';
 
       // 멘션 추출
-      const mentionedUser = this.extractMention(messageEvent.text);
-      const isMention = !!mentionedUser;
+      const mentionedUsers = extractAllMentionedUsers(messageEvent.text);
+      const firstMentionedUser =
+        mentionedUsers.length > 0 ? mentionedUsers[0] : null;
 
-      // 로그 데이터 생성
+      // 리마인더봇 타겟 사용자 식별
+      let reminderTargetUser: string | null = null;
+      let isTargetInThread = false;
+
+      // 스레드 메시지인 경우, 원본 스레드의 타겟 사용자 식별
+      if (isThreadMessage(messageEvent)) {
+        if (messageEvent.thread_ts) {
+          reminderTargetUser = await this.identifyThreadTargetUser(
+            messageEvent.thread_ts,
+          );
+          // 현재 메시지 작성자가 타겟 사용자와 동일한지 확인
+          isTargetInThread =
+            !!reminderTargetUser && reminderTargetUser === messageEvent.user;
+        }
+      } else if (isReminderBot) {
+        // 리마인더봇 원본 메시지인 경우, 타겟 사용자 바로 추출
+        reminderTargetUser = extractReminderTargetUser(messageEvent);
+      }
+
+      // 로그 데이터 생성 (확장된 필드 포함)
       const logData: ConversationLog = {
         member_code: memberCode,
         slack_member_id: messageEvent.user,
@@ -68,9 +115,16 @@ export class ConversationLogService {
         thread_ts: messageEvent.thread_ts || null,
         parent_user_id: messageEvent.parent_user_id || null,
         is_thread_reply: isThreadMessage(messageEvent),
-        is_reminder_thread: isReminderBotParent(messageEvent),
-        is_mention: isMention,
-        mentioned_user: mentionedUser,
+        is_reminder_thread: isReminderBot || isReminderBotParent(messageEvent),
+        is_mention: mentionedUsers.length > 0,
+        mentioned_user: firstMentionedUser,
+        mentioned_users: mentionedUsers, // 모든 멘션된 사용자 목록
+        is_reminder_target: isTargetInThread, // 이 사용자가 리마인더 타겟인지 여부
+        reminder_target_user: reminderTargetUser, // 리마인더 타겟 사용자
+        authorization_users:
+          event.authorizations?.map((auth) => auth.user_id) || // 권한 있는 사용자들
+          event.authed_users || // 이전 버전 호환
+          [],
       };
 
       // 저장

--- a/laboratory/libs/slack/types/slack-webhook-message.ts
+++ b/laboratory/libs/slack/types/slack-webhook-message.ts
@@ -58,6 +58,7 @@ interface SlackEventCallback extends SlackEventBase {
   event_context?: string;
   context_team_id?: string;
   context_enterprise_id?: string | null;
+  authed_users?: string[]; // 이전 버전 호환성을 위해 유지
 }
 
 // 모든 이벤트 타입을 하나로 통합
@@ -85,6 +86,32 @@ export const isThreadMessage = (event: SlackMessageEvent): boolean => {
 // 리마인더봇 메시지인지 확인하는 함수
 export const isReminderBotParent = (event: SlackMessageEvent): boolean => {
   return !!event.parent_user_id && event.parent_user_id === REMINDER_BOT_ID;
+};
+
+// 리마인더봇이 생성한 원본 메시지인지 확인하는 함수
+export const isReminderBotMessage = (event: SlackMessageEvent): boolean => {
+  return event.bot_id === REMINDER_BOT_ID;
+};
+
+// 메시지에서 리마인더봇이 언급한 주요 대상 사용자 식별
+export const extractReminderTargetUser = (
+  event: SlackMessageEvent,
+): string | null => {
+  // 리마인더봇 메시지가 아니면 null 반환
+  if (!isReminderBotMessage(event)) {
+    return null;
+  }
+
+  // 메시지에서 첫 번째 멘션을 대상 사용자로 간주
+  return extractFirstMentionedUser(event.text);
+};
+
+// 스레드 참여자가 대상 사용자인지 확인하는 함수
+export const isTargetUser = (
+  threadTargetUserId: string,
+  userId: string,
+): boolean => {
+  return threadTargetUserId === userId;
 };
 
 // 멘션 관련 유틸리티 함수 추가


### PR DESCRIPTION
# 개선된 사항
## 리마인더봇 메시지 식별 기능 개선
- isReminderBotMessage() 함수 추가: 리마인더봇이 생성한 메시지를 식별
- extractReminderTargetUser() 함수 추가: 리마인더봇 메시지에서 대상 사용자 추출
## 스레드 관계 분석 강화
- 스레드 내에서 대화 주체인 사용자와 참여자 구분
- 원본 메시지 조회 기능 findThreadOriginMessage() 추가
- 스레드 대상 사용자 식별 로직 identifyThreadTargetUser() 추가
## 데이터 모델 확장
- ConversationLog 인터페이스에 새 필드 추가:
- mentioned_users: 모든 멘션된 사용자 목록
- is_reminder_target: 대화 주체 여부 표시
- reminder_target_user: 리마인더 대상 사용자
- authorization_users: 이벤트 접근 권한 사용자 목록
## Slack API 호환성 개선
- [Slack 문서에 명시](https://api.slack.com/apis/events-api#event_type_structure)된 authorizations 배열 처리
- 이전 버전 호환을 위한 authed_users 필드 지원