### PR TITLE
fix: conversation_log insert형식(json) & entity수정

### DIFF
--- a/laboratory/libs/domains/conversation-log/entities/conversation-log.entity.ts
+++ b/laboratory/libs/domains/conversation-log/entities/conversation-log.entity.ts
@@ -10,10 +10,10 @@ export interface ConversationLog {
   is_thread_reply: boolean;
   is_mention: boolean;
   mentioned_user?: string | null;
-  mentioned_users?: string[];
+  mentioned_users?: string;
   is_reminder_thread: boolean;
   is_reminder_target?: boolean;
   reminder_target_user?: string | null;
-  authorization_users?: string[];
+  authorization_users?: string;
   created_at?: Date;
 }

--- a/laboratory/libs/domains/conversation-log/services/conversation-log.service.ts
+++ b/laboratory/libs/domains/conversation-log/services/conversation-log.service.ts
@@ -118,13 +118,14 @@ export class ConversationLogService {
         is_reminder_thread: isReminderBot || isReminderBotParent(messageEvent),
         is_mention: mentionedUsers.length > 0,
         mentioned_user: firstMentionedUser,
-        mentioned_users: mentionedUsers, // 모든 멘션된 사용자 목록
+        mentioned_users: JSON.stringify(mentionedUsers), // JSON 문자열로 변환
         is_reminder_target: isTargetInThread, // 이 사용자가 리마인더 타겟인지 여부
         reminder_target_user: reminderTargetUser, // 리마인더 타겟 사용자
-        authorization_users:
-          event.authorizations?.map((auth) => auth.user_id) || // 권한 있는 사용자들
-          event.authed_users || // 이전 버전 호환
-          [],
+        authorization_users: JSON.stringify(
+          event.authorizations?.map((auth) => auth.user_id) ||
+            event.authed_users ||
+            [],
+        ), // JSON 문자열로 변환
       };
 
       // 저장


### PR DESCRIPTION
# SQL 오류는 mentioned_users 필드에 빈 값이 전달되었기 때문에 발생
- mentioned_users와 authorization_users 필드를 JSON 배열 대신 JSON 문자열로 변경
- 서비스에서 JSON.stringify()를 사용하여 배열을 JSON 문자열로 직렬화
- 데이터베이스에 들어갈 때는 항상 유효한 JSON 값이 들어가도록 보장
