### PR TITLE
fix: 스레드 작성 유저가 멘션유저인지 판단(json오류처리)

### DIFF
--- a/laboratory/libs/slack/types/slack-webhook-message.ts
+++ b/laboratory/libs/slack/types/slack-webhook-message.ts
@@ -90,6 +90,7 @@ export const isReminderBotParent = (event: SlackMessageEvent): boolean => {
 
 // 리마인더봇이 생성한 원본 메시지인지 확인하는 함수
 export const isReminderBotMessage = (event: SlackMessageEvent): boolean => {
+  // bot_id가 있고, 해당 ID가 REMINDER_BOT_ID와 같은 경우
   return event.bot_id === REMINDER_BOT_ID;
 };
 
@@ -102,7 +103,39 @@ export const extractReminderTargetUser = (
     return null;
   }
 
+  // 디버깅용 로그 (개발 완료 후 제거)
+  console.log('리마인더봇 메시지 분석:', {
+    text: event.text,
+    bot_id: event.bot_id,
+    reminder_bot_id: REMINDER_BOT_ID,
+  });
+
+  // 메시지 텍스트 유효성 검사
+  if (!event.text) {
+    return null;
+  }
+
   // 메시지에서 첫 번째 멘션을 대상 사용자로 간주
+  // 1. 메시지 블록에서 멘션 확인
+  if (event.blocks && Array.isArray(event.blocks)) {
+    // 블록 내 멘션 확인
+    for (const block of event.blocks) {
+      if (block.elements && Array.isArray(block.elements)) {
+        for (const element of block.elements) {
+          if (element.elements && Array.isArray(element.elements)) {
+            for (const subElement of element.elements) {
+              if (subElement.type === 'user' && subElement.user_id) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+                return subElement.user_id;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // 2. 텍스트에서 멘션 추출
   return extractFirstMentionedUser(event.text);
 };
 


### PR DESCRIPTION
# mentioned_users JSON 파싱 추가:
- 기존에는 문자열로 저장된 mentioned_users를 배열처럼 접근하여 오류 발생
- JSON 문자열을 적절히 파싱하고 예외 처리 추가
# 리마인더봇 메시지 식별 강화:
- 블록 구조에서도 멘션된 사용자를 추출하는 기능 추가
- 슬랙 리치 메시지 포맷 지원 강화
# 디버깅 로그 추가:
- 문제 진단을 위한 상세 로그 추가
- 타겟 사용자 식별 과정을 단계별로 로깅
# 기존 문제의 원인:
- mentioned_users가 JSON 문자열로 저장되었는데 배열로 직접 접근 시도
- 스레드 원본 메시지에서 대상 사용자를 추출하는 로직이 불완전
- 리마인더봇 메시지의 구조적 특성을 충분히 활용하지 못함
